### PR TITLE
Handle polygon color serialization

### DIFF
--- a/graphics/lib/project_models.dart
+++ b/graphics/lib/project_models.dart
@@ -212,6 +212,8 @@ class LayeredCanvasItem {
       'backgroundColor',
       'textColor',
       'borderColor',
+      'strokeColor',
+      'fillColor',
       // Add more color property keys as needed
     ];
 
@@ -234,6 +236,8 @@ class LayeredCanvasItem {
       'backgroundColor',
       'textColor',
       'borderColor',
+      'strokeColor',
+      'fillColor',
       // Add more color property keys as needed
     ];
 

--- a/web_runtime/lib/web_runtime_models.dart
+++ b/web_runtime/lib/web_runtime_models.dart
@@ -172,6 +172,8 @@ class LayeredCanvasItem {
       'backgroundColor',
       'textColor',
       'borderColor',
+      'strokeColor',
+      'fillColor',
       // Add more color property keys as needed
     ];
 
@@ -194,6 +196,8 @@ class LayeredCanvasItem {
       'backgroundColor',
       'textColor',
       'borderColor',
+      'strokeColor',
+      'fillColor',
       // Add more color property keys as needed
     ];
 


### PR DESCRIPTION
## Summary
- support `strokeColor` and `fillColor` when serializing `LayeredCanvasItem`

## Testing
- `dart format graphics/lib/project_models.dart web_runtime/lib/web_runtime_models.dart` *(fails: command not found)*
- `flutter format graphics/lib/project_models.dart web_runtime/lib/web_runtime_models.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541ee3b6a08327a2f3cbaa6897b34d